### PR TITLE
0.4 Support depth buffer & simplify layout usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 **/*.rs.bk
 Cargo.lock
+benches/*.stdout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_glyph"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Alex Butler <alexheretic@gmail.com>"]
 description = "Fast GPU cached text rendering using gfx-rs & rusttype"
 repository = "https://github.com/alexheretic/gfx-glyph"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Have a look at
 **0.4**
 * Support depth testing with configurable gfx depth test (via `GlyphBrushBuilder::depth_test`).
   * `Section`s now have a `z` value to indicate the depth.
+  * Actual depth testing is disabled by default, but a reference to the depth buffer is now required to draw.
 * Streamline API for use with built-in `Layout`s, while still allowing custom layouts.
   * Built-in layouts are now a member of `Section`.
   * Custom layouts can still be used by using `GlyphBrush::queue_custom_layout` method instead of `queue`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ sequential frames.
 
 ```rust
 extern crate gfx_glyph;
-use gfx_glyph::{Section, Layout, GlyphBrushBuilder};
+use gfx_glyph::{Section, GlyphBrushBuilder};
 
 let arial: &[u8] = include_bytes!("examples/Arial Unicode.ttf");
 let mut glyph_brush = GlyphBrushBuilder::using_font(arial)
@@ -30,10 +30,10 @@ let section = Section {
     ..Section::default() // color, position, etc
 };
 
-glyph_brush.queue(section, &Layout::default());
-glyph_brush.queue(some_other_section, &Layout::default());
+glyph_brush.queue(section);
+glyph_brush.queue(some_other_section);
 
-glyph_brush.draw_queued(&mut gfx_encoder, &gfx_target).unwrap();
+glyph_brush.draw_queued(&mut gfx_encoder, &gfx_color, &gfx_depth).unwrap();
 ```
 
 ## Limitations
@@ -45,6 +45,16 @@ Have a look at
 * `cargo run --example performance --release`
 
 ## Changelog
+**0.4**
+* Support depth testing with configurable gfx depth test (via `GlyphBrushBuilder::depth_test`).
+  * `Section`s now have a `z` value to indicate the depth.
+* Streamline API for use with built-in `Layout`s, while still allowing custom layouts.
+  * Built-in layouts are now a member of `Section`.
+  * Custom layouts can still be used by using `GlyphBrush::queue_custom_layout` method instead of `queue`.
+  * `Section<'a, L>` are now generic to allow pluggable `LineBreaker` logic in the layout. This is a little unfortunate for the API surface.
+* Remove unnecessary `OwnedSection` and `StaticSection` to simplify the API.
+* `pixel_bounding_box` renamed to `pixel_bounds` & `pixel_bounds_custom_layout`
+
 **0.3**
 * Use `Into<SharedBytes>` instead of explicit `&[u8]` for font byte input to improve flexibility.
 
@@ -53,8 +63,8 @@ Notable non-breaking changes:
   * Move fixed GPU caching logic into crate replacing `rusttype::gpu_cache`
   * `Section` & `StaticSection` implement `Copy`
 * **0.3.3**
-  * Fix another GPU caching issues that could cause missing glyphs
-  * Fix layout issue that could miss a character immediately preceding EOF
+  * Fix another GPU caching issue that could cause missing glyphs
+  * Fix a layout issue that could miss a character immediately preceding EOF
   * Optimise GPU cache sorting performance
 
 **0.2**

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Have a look at
   * `Section<'a, L>` are now generic to allow pluggable `LineBreaker` logic in the layout. This is a little unfortunate for the API surface.
 * Remove unnecessary `OwnedSection` and `StaticSection` to simplify the API.
 * `pixel_bounding_box` renamed to `pixel_bounds` & `pixel_bounds_custom_layout`
+  * These now return `Option<_>` to handle the bounds of 'nothing' properly
+* `GlyphBrushBuilder` `gpu_cache_position_tolerance` default reduced to 0.1 (from 1.0)
 
 **0.3**
 * Use `Into<SharedBytes>` instead of explicit `&[u8]` for font byte input to improve flexibility.

--- a/bench
+++ b/bench
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $dir
+
+if [ "${1:-}" == "--help" ] || [ "${1:-}" == "-h" ]; then
+  echo "Micro-benchmarks for gfx_glyph"
+  echo "  Setup a control / starting values to compare against"
+  echo "  > ./bench --control"
+  echo ''
+  echo '  With a control recorded, re-evaluate and compare:'
+  echo '  > ./bench'
+  echo ''
+  echo '  Can also add cargo-benchcmp arguments to change the comparison output'
+  echo '  > ./bench --threshold 2'
+  exit 0
+fi
+
+if [ "${1:-}" == "--control" ]; then
+  echo 'running bench > benches/control.stdout' >&2
+  rustup run nightly cargo bench --features bench \
+    | tee benches/control.stdout \
+    | grep --color=never 'bench:'
+  exit 0
+fi
+
+if [ ! -f benches/control.stdout ]; then
+  echo 'benches/control.stdout missing, will not perform a benchmark comparison' >&2
+  echo '  run `./bench --control` to generate from the current source' >&2
+  # just run a bench
+  rustup run nightly cargo bench --features bench
+else
+  echo 'running bench > benches/change.stdout' >&2
+
+  rustup run nightly cargo bench --features bench \
+    | tee benches/change.stdout \
+    | grep --color=never 'bench:'
+
+  echo ''
+
+  cargo benchcmp benches/control.stdout benches/change.stdout "$@"
+fi

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -25,27 +25,25 @@ fn render_3_medium_sections_fully(b: &mut ::test::Bencher) {
     let text = include_str!("lipsum.txt");
 
     bench(b,
-        &[(
-            StaticSection {
+        &[
+            Section {
                 text,
                 bounds: (600.0, f32::INFINITY),
-                ..StaticSection::default() },
-            Layout::Wrap(StandardLineBreaker, HorizontalAlign::Left)
-        ), (
-            StaticSection {
+                layout: Layout::Wrap(StandardLineBreaker, HorizontalAlign::Left),
+                ..Section::default() },
+            Section {
                 text,
                 screen_position: (600.0, 0.0),
                 bounds: (600.0, f32::INFINITY),
-                ..StaticSection::default() },
-            Layout::Wrap(StandardLineBreaker, HorizontalAlign::Center)
-        ), (
-            StaticSection {
+                layout: Layout::Wrap(StandardLineBreaker, HorizontalAlign::Center),
+                ..Section::default() },
+            Section {
                 text,
                 screen_position: (1200.0, 0.0),
                 bounds: (600.0, f32::INFINITY),
-                ..StaticSection::default() },
-            Layout::Wrap(StandardLineBreaker, HorizontalAlign::Right)
-        )],
+                layout: Layout::Wrap(StandardLineBreaker, HorizontalAlign::Right),
+                ..Section::default() },
+        ],
         brush);
 }
 
@@ -62,27 +60,25 @@ fn no_cache_render_3_medium_sections_fully(b: &mut ::test::Bencher) {
     let text = include_str!("lipsum.txt");
 
     bench(b,
-        &[(
-            StaticSection {
+        &[
+            Section {
                 text,
                 bounds: (600.0, f32::INFINITY),
-                ..StaticSection::default() },
-            Layout::Wrap(StandardLineBreaker, HorizontalAlign::Left)
-        ), (
-            StaticSection {
+                layout: Layout::Wrap(StandardLineBreaker, HorizontalAlign::Left),
+                ..Section::default() },
+            Section {
                 text,
                 screen_position: (600.0, 0.0),
                 bounds: (600.0, f32::INFINITY),
-                ..StaticSection::default() },
-            Layout::Wrap(StandardLineBreaker, HorizontalAlign::Center)
-        ), (
-            StaticSection {
+                layout: Layout::Wrap(StandardLineBreaker, HorizontalAlign::Center),
+                ..Section::default() },
+            Section {
                 text,
                 screen_position: (1200.0, 0.0),
                 bounds: (600.0, f32::INFINITY),
-                ..StaticSection::default() },
-            Layout::Wrap(StandardLineBreaker, HorizontalAlign::Right)
-        )],
+                layout: Layout::Wrap(StandardLineBreaker, HorizontalAlign::Right),
+                ..Section::default() }
+        ],
         brush);
 }
 
@@ -95,11 +91,11 @@ fn render_1_large_section_partially(b: &mut ::test::Bencher) {
     let text = include_str!("lots_of_lipsum.txt");
 
     bench(b,
-        &[(StaticSection {
+        &[Section {
             text,
             bounds: (600.0, 600.0),
-            ..StaticSection::default()
-        }, Layout::default())],
+            ..Section::default()
+        }],
         brush);
 }
 
@@ -115,11 +111,11 @@ fn no_cache_render_1_large_section_partially(b: &mut ::test::Bencher) {
     let text = include_str!("lots_of_lipsum.txt");
 
     bench(b,
-        &[(StaticSection {
+        &[Section {
             text,
             bounds: (600.0, 600.0),
-            ..StaticSection::default()
-        }, Layout::default())],
+            ..Section::default()
+        }],
         brush);
 }
 
@@ -134,12 +130,12 @@ fn render_100_small_sections_fully(b: &mut ::test::Bencher) {
 
     let mut section_layouts = vec![];
     for i in 0..100 {
-        section_layouts.push((StaticSection {
+        section_layouts.push(Section {
             text,
             screen_position: (i as f32, 0.0),
             bounds: (100.0, f32::INFINITY),
-            ..StaticSection::default()
-        }, Layout::default()));
+            ..Section::default()
+        });
     }
 
     bench(b, &section_layouts, brush);
@@ -159,12 +155,12 @@ fn no_cache_render_100_small_sections_fully(b: &mut ::test::Bencher) {
 
     let mut section_layouts = vec![];
     for i in 0..100 {
-        section_layouts.push((StaticSection {
+        section_layouts.push(Section {
             text,
             screen_position: (i as f32, 0.0),
             bounds: (100.0, f32::INFINITY),
-            ..StaticSection::default()
-        }, Layout::default()));
+            ..Section::default()
+        });
     }
 
     bench(b, &section_layouts, brush);
@@ -173,7 +169,7 @@ fn no_cache_render_100_small_sections_fully(b: &mut ::test::Bencher) {
 #[cfg(feature = "bench")]
 fn bench<L: gfx_glyph::LineBreaker>(
     b: &mut ::test::Bencher,
-    sections: &[(gfx_glyph::StaticSection, gfx_glyph::Layout<L>)],
+    sections: &[gfx_glyph::Section<'static, L>],
     brush: gfx_glyph::GlyphBrushBuilder)
 {
     use gfx::format;
@@ -188,7 +184,7 @@ fn bench<L: gfx_glyph::LineBreaker>(
 
     // TODO use headless/fake
     let events_loop = glutin::EventsLoop::new();
-    let (_window, _device, factory, main_color, _main_depth) =
+    let (_window, _device, factory, main_color, main_depth) =
         gfx_window_glutin::init::<format::Srgba8, format::Depth>(
             glutin::WindowBuilder::new().with_dimensions(1, 1),
             glutin::ContextBuilder::new(),
@@ -198,9 +194,9 @@ fn bench<L: gfx_glyph::LineBreaker>(
     let mut glyph_brush = brush.build(factory.clone());
 
     b.iter(|| {
-        for &(ref section, ref layout) in sections.iter() {
-            glyph_brush.queue(section.clone(), layout);
+        for section in sections.iter() {
+            glyph_brush.queue(*section);
         }
-        glyph_brush.draw_queued(&mut encoder, &main_color).expect("draw");
+        glyph_brush.draw_queued(&mut encoder, &main_color, &main_depth).expect("draw");
     });
 }

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -45,7 +45,6 @@ fn main() {
 
     let mut glyph_brush = gfx_glyph::GlyphBrushBuilder::using_font(include_bytes!("Arial Unicode.ttf") as &[u8])
         .initial_cache_size((1024, 1024))
-        .gpu_cache_position_tolerance(0.2)
         .build(factory.clone());
 
     let mut text: String = include_str!("lipsum.txt").into();

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -43,6 +43,7 @@ fn main() {
 
     let mut glyph_brush = GlyphBrushBuilder::using_font(include_bytes!("Arial Unicode.ttf") as &[u8])
         .initial_cache_size((2048, 2048))
+        .gpu_cache_position_tolerance(1.0)
         .build(factory.clone());
 
     let mut text: String = include_str!("100000_items.txt").into();

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -99,7 +99,6 @@ fn main() {
 
         // The section is all the info needed for the glyph brush to render a 'section' of text
         // can use `..Section::default()` to skip the bits you don't care about
-        // also see convenience variants StaticSection & OwnedSection
         let section = Section {
             text: &text,
             scale: font_size,
@@ -108,8 +107,9 @@ fn main() {
             ..Section::default()
         };
 
-        // the lib needs layout logic to render the glyphs, ie a gfx_glyph::GlyphPositioner
-        // See the built-in ones, ie Layout::default()
+        // Custom layout logic to render the glyphs is allowed by implementing
+        // `gfx_glyph::GlyphPositioner`
+        // Built-in layouts are available e.g. `Layout::default()`
         // This is an example of implementing your own, see below
         let layout = CustomContiguousParagraphLayout;
 
@@ -117,7 +117,7 @@ fn main() {
         // can be called multiple times for different sections that want to use the same
         // font and gpu cache
         // This step computes the glyph positions, this is cached to avoid unnecessary recalculation
-        glyph_brush.queue(section, &layout);
+        glyph_brush.queue_custom_layout(section, &layout);
 
         // Finally once per frame you want to actually draw all the sections you've submitted
         // with `queue` calls.
@@ -125,7 +125,7 @@ fn main() {
         // Note: Drawing in the case the text is unchanged from the previous frame (a common case)
         // is essentially free as the vertices are reused &  gpu cache updating interaction
         // can be skipped.
-        glyph_brush.draw_queued(&mut encoder, &main_color).expect("draw");
+        glyph_brush.draw_queued(&mut encoder, &main_color, &main_depth).expect("draw");
 
         encoder.flush(&mut device);
         window.swap_buffers().unwrap();

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -49,8 +49,8 @@ impl<'a> GlyphInfo<'a> {
     }
 }
 
-impl<'a, 'b> From<&'b Section<'a>> for GlyphInfo<'a> {
-    fn from(section: &'b Section<'a>) -> Self {
+impl<'a, 'b, L: LineBreaker> From<&'b Section<'a, L>> for GlyphInfo<'a> {
+    fn from(section: &'b Section<'a, L>) -> Self {
         let Section { text, screen_position, bounds, scale, .. } = *section;
         Self {
             text,
@@ -105,7 +105,7 @@ pub trait LineBreaker: fmt::Debug + Copy + Hash {
 /// Takes generic [`LineBreaker`](trait.LineBreaker.html) to indicate the wrapping style.
 /// See [`StandardLineBreaker`](struct.StandardLineBreaker.html),
 /// [`AnyCharLineBreaker`](struct.AnyCharLineBreaker.html).
-#[derive(Debug, Clone, Copy, Hash)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum Layout<L: LineBreaker> {
     /// Renders a single line from left-to-right according to the inner alignment.
     /// Hard breaking will end the line, partially hitting the width bound will end the line.

--- a/src/shader/vert.glsl
+++ b/src/shader/vert.glsl
@@ -2,7 +2,7 @@
 
 uniform mat4 transform;
 
-in vec2 pos;
+in vec3 pos;
 in vec2 tex_pos;
 in vec4 color;
 
@@ -12,5 +12,5 @@ out vec4 f_color;
 void main() {
     f_color = color;
     f_tex_pos = tex_pos;
-    gl_Position = transform * vec4(pos, 0.0, 1.0);
+    gl_Position = transform * vec4(pos, 1.0);
 }


### PR DESCRIPTION
I need depth testing now in Robo Instructus, so I've added that functionality along with some streamlining of the API as `0.4`. This is quite a breaking change unfortunately, but for the best I think.

I'll let this PR brew for a few days before merging. Please checkout the changes and comment if you're interested.

### Changes
* Support depth testing with configurable gfx depth test (via
`GlyphBrushBuilder::depth_test`).
  * `Section`s now have a `z` value to indicate the depth.
  * Actual depth testing is disabled by default, but a reference to the depth buffer is now required to draw.
* Streamline API for use with built-in `Layout`s, while still allowing
custom layouts.
  * Built-in layouts are now a member of `Section`.
  * Custom layouts can still be used by using
`GlyphBrush::queue_custom_layout` method instead of `queue`.
  * `Section<'a, L>` are now generic to allow pluggable `LineBreaker`
logic in the layout. This is a little unfortunate for the API surface.
* Remove unnecessary `OwnedSection` and `StaticSection` to simplify the
API.
* `pixel_bounding_box` renamed to `pixel_bounds` &
`pixel_bounds_custom_layout`