### PR TITLE
Add builder using font type

### DIFF
--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -36,11 +36,11 @@ fn main() {
             &events_loop,
         );
 
-    let mut builder = GlyphBrushBuilder::using_font(include_bytes!("Arial Unicode.ttf") as &[u8])
+    let mut builder = GlyphBrushBuilder::using_font_bytes(include_bytes!("Arial Unicode.ttf") as &[u8])
         // Enable depth testing with less-equal drawing and update the depth buffer
         .depth_test(gfx::preset::depth::LESS_EQUAL_WRITE);
 
-    let italic_font = builder.add_font(include_bytes!("OpenSans-Italic.ttf") as &[u8]);
+    let italic_font = builder.add_font_bytes(include_bytes!("OpenSans-Italic.ttf") as &[u8]);
     let mut glyph_brush = builder.build(factory.clone());
 
     let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -44,7 +44,7 @@ fn main() {
     let (window, mut device, mut factory, mut main_color, mut main_depth) =
         gfx_window_glutin::init::<format::Srgba8, format::DepthStencil>(window_builder, context, &events_loop);
 
-    let mut glyph_brush = gfx_glyph::GlyphBrushBuilder::using_font(include_bytes!("Arial Unicode.ttf") as &[u8])
+    let mut glyph_brush = gfx_glyph::GlyphBrushBuilder::using_font_bytes(include_bytes!("Arial Unicode.ttf") as &[u8])
         .initial_cache_size((1024, 1024))
         .build(factory.clone());
 

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -42,7 +42,7 @@ fn main() {
     let (window, mut device, mut factory, mut main_color, mut main_depth) =
         gfx_window_glutin::init::<format::Srgba8, format::Depth>(window_builder, context, &events_loop);
 
-    let mut glyph_brush = GlyphBrushBuilder::using_font(include_bytes!("Arial Unicode.ttf") as &[u8])
+    let mut glyph_brush = GlyphBrushBuilder::using_font_bytes(include_bytes!("Arial Unicode.ttf") as &[u8])
         .initial_cache_size((2048, 2048))
         .gpu_cache_position_tolerance(1.0)
         .build(factory.clone());

--- a/examples/varied.rs
+++ b/examples/varied.rs
@@ -47,11 +47,11 @@ fn main() {
             &events_loop,
         );
 
-    let mut builder = GlyphBrushBuilder::using_font(include_bytes!("Arial Unicode.ttf") as &[u8]);
+    let mut builder = GlyphBrushBuilder::using_font_bytes(include_bytes!("Arial Unicode.ttf") as &[u8]);
     let sans_font = FontId::default();
-    let italic_font = builder.add_font(include_bytes!("OpenSans-Italic.ttf") as &[u8]);
-    let serif_font = builder.add_font(include_bytes!("GaramondNo8-Reg.ttf") as &[u8]);
-    let mono_font = builder.add_font(include_bytes!("../tests/DejaVuSansMono.ttf") as &[u8]);
+    let italic_font = builder.add_font_bytes(include_bytes!("OpenSans-Italic.ttf") as &[u8]);
+    let serif_font = builder.add_font_bytes(include_bytes!("GaramondNo8-Reg.ttf") as &[u8]);
+    let mono_font = builder.add_font_bytes(include_bytes!("../tests/DejaVuSansMono.ttf") as &[u8]);
 
     let mut glyph_brush = builder.build(factory.clone());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! # let mut gfx_encoder: gfx::Encoder<_, _> = gfx_factory.create_command_buffer().into();
 //!
 //! let arial: &[u8] = include_bytes!("../examples/Arial Unicode.ttf");
-//! let mut glyph_brush = GlyphBrushBuilder::using_font(arial)
+//! let mut glyph_brush = GlyphBrushBuilder::using_font_bytes(arial)
 //!     .build(gfx_factory.clone());
 //!
 //! # let some_other_section = Section { text: "another", ..Section::default() };
@@ -154,7 +154,7 @@ fn hash<H: Hash>(hashable: &H) -> u64 {
 /// # let mut gfx_encoder: gfx::Encoder<_, _> = gfx_factory.create_command_buffer().into();
 ///
 /// # let arial: &[u8] = include_bytes!("../examples/Arial Unicode.ttf");
-/// # let mut glyph_brush = GlyphBrushBuilder::using_font(arial)
+/// # let mut glyph_brush = GlyphBrushBuilder::using_font_bytes(arial)
 /// #     .build(gfx_factory.clone());
 ///
 /// # let some_other_section = Section { text: "another", ..Section::default() };


### PR DESCRIPTION
This PR adds the ability to produce GlyphBrushes with the rusttype::Font type.  For users who manage their own Font values this can help reduce the amount of times a font is interpreted.