### PR TITLE
Add function for retrieving cached glyph positions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,7 +286,7 @@ impl<'font, R: gfx::Resources, F: gfx::Factory<R>> GlyphBrush<'font, R, F> {
     {
         let section = section.into();
         let layout = section.layout;
-        self.cached_glyphs_custom_layout(section, &layout)
+        self.glyphs_custom_layout(section, &layout)
     }
 
     /// Queues a section/layout to be drawn by the next call of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ impl<'font, R: gfx::Resources, F: gfx::Factory<R>> GlyphBrush<'font, R, F> {
     /// Returns an iterator over the `PositionedGlyph`s of the given section with a custom layout.
     ///
     /// If the glyphs have already been cached this will skip re-computing them.
-    pub fn cached_glyphs_custom_layout<'a, S, L>(&mut self, section: S, custom_layout: &L)
+    pub fn glyphs_custom_layout<'a, S, L>(&mut self, section: S, custom_layout: &L)
         -> PositionedGlyphIter
         where L: GlyphPositioner + Hash,
               S: Into<Cow<'a, VariedSection<'a>>>,
@@ -280,7 +280,7 @@ impl<'font, R: gfx::Resources, F: gfx::Factory<R>> GlyphBrush<'font, R, F> {
     /// Returns an iterator over the `PositionedGlyph`s of the given section.
     ///
     /// If the glyphs have already been cached this will skip re-computing them.
-    pub fn cached_glyphs<'a, S>(&mut self, section: S)
+    pub fn ,glyphsglyphs<'a, S>(&mut self, section: S)
         -> PositionedGlyphIter
         where S: Into<Cow<'a, VariedSection<'a>>>,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ impl<'font, R: gfx::Resources, F: gfx::Factory<R>> GlyphBrush<'font, R, F> {
     /// Returns an iterator over the `PositionedGlyph`s of the given section.
     ///
     /// If the glyphs have already been cached this will skip re-computing them.
-    pub fn ,glyphsglyphs<'a, S>(&mut self, section: S)
+    pub fn glyphs<'a, S>(&mut self, section: S)
         -> PositionedGlyphIter
         where S: Into<Cow<'a, VariedSection<'a>>>,
     {


### PR DESCRIPTION
As discussed on gitter.

This PR adds functions to allow downstream users to use the cached glyph positions and avoid having to re-compute the positions themselves.