### PR TITLE
0.7.0: HeadlessGlyphBrush + rusttype 0.3 no-copy cache optimisation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme="README.md"
 
 [dependencies]
 log = "0.3"
-rusttype = "0.2.3"
+rusttype = { path = "../rusttype" } #"0.3"
 gfx = "0.16"
 gfx_core = "0.7"
 unicode-normalization = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme="README.md"
 
 [dependencies]
 log = "0.3"
-rusttype = { git = "https://github.com/redox-os/rusttype" } #"0.3"
+rusttype = "0.3"
 gfx = "0.16"
 gfx_core = "0.7"
 unicode-normalization = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme="README.md"
 
 [dependencies]
 log = "0.3"
-rusttype = { path = "../rusttype" } #"0.3"
+rusttype = { git = "https://github.com/redox-os/rusttype" } #"0.3"
 gfx = "0.16"
 gfx_core = "0.7"
 unicode-normalization = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_glyph"
-version = "0.6.4"
+version = "0.7.0"
 authors = ["Alex Butler <alexheretic@gmail.com>"]
 description = "Fast GPU cached text rendering using gfx-rs & rusttype"
 repository = "https://github.com/alexheretic/gfx-glyph"

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -151,11 +151,11 @@ pub struct CustomContiguousParagraphLayout;
 impl gfx_glyph::GlyphPositioner for CustomContiguousParagraphLayout {
 
     /// Calculate a sequence of positioned glyphs to render
-    fn calculate_glyphs<'a, G: Into<SectionGlyphInfo<'a>>>(
+    fn calculate_glyphs<'a, 'font, G: Into<SectionGlyphInfo<'a>>>(
         &self,
-        fonts: &HashMap<FontId, Font>,
-        section: G
-    ) -> Vec<GlyphedSectionText> {
+        fonts: &HashMap<FontId, Font<'font>>,
+        section: G,
+    ) -> Vec<GlyphedSectionText<'font>> {
 
         let mut glyph_info = section.into();
         let original_screen_x = glyph_info.screen_position.0;

--- a/src/glyph_calculator.rs
+++ b/src/glyph_calculator.rs
@@ -1,0 +1,57 @@
+use super::*;
+
+pub trait GlyphCalculator<'font> {
+    /// Returns the pixel bounding box for the input section using a custom layout.
+    /// The box is a conservative whole number pixel rectangle that can contain the section.
+    ///
+    /// If the section is empty or would result in no drawn glyphs will return `None`
+    ///
+    /// Benefits from caching, see [caching behaviour](#caching-behaviour).
+    fn pixel_bounds_custom_layout<'a, S, L>(
+        &mut self,
+        section: S,
+        custom_layout: &L,
+    ) -> Option<Rect<i32>>
+    where
+        L: GlyphPositioner + Hash,
+        S: Into<Cow<'a, VariedSection<'a>>>;
+
+    /// Returns the pixel bounding box for the input section. The box is a conservative
+    /// whole number pixel rectangle that can contain the section.
+    ///
+    /// If the section is empty or would result in no drawn glyphs will return `None`
+    ///
+    /// Benefits from caching, see [caching behaviour](#caching-behaviour).
+    fn pixel_bounds<'a, S>(&mut self, section: S) -> Option<Rect<i32>>
+    where
+        S: Into<Cow<'a, VariedSection<'a>>>,
+    {
+        let section = section.into();
+        let layout = section.layout;
+        self.pixel_bounds_custom_layout(section, &layout)
+    }
+
+    /// Returns an iterator over the `PositionedGlyph`s of the given section with a custom layout.
+    ///
+    /// Benefits from caching, see [caching behaviour](#caching-behaviour).
+    fn glyphs_custom_layout<'a, 'b, S, L>(
+        &'b mut self,
+        section: S,
+        custom_layout: &L,
+    ) -> PositionedGlyphIter<'b, 'font>
+    where
+        L: GlyphPositioner + Hash,
+        S: Into<Cow<'a, VariedSection<'a>>>;
+
+    /// Returns an iterator over the `PositionedGlyph`s of the given section.
+    ///
+    /// Benefits from caching, see [caching behaviour](#caching-behaviour).
+    fn glyphs<'a, 'b, S>(&'b mut self, section: S) -> PositionedGlyphIter<'b, 'font>
+    where
+        S: Into<Cow<'a, VariedSection<'a>>>,
+    {
+        let section = section.into();
+        let layout = section.layout;
+        self.glyphs_custom_layout(section, &layout)
+    }
+}

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1,0 +1,183 @@
+use super::*;
+use linked_hash_map::LinkedHashMap;
+
+/// Cut down version of a [`GlyphBrush`](struct.GlyphBrush.html) that can calculate pixel bounds,
+/// but is unable to actually render anything.
+///
+/// Build using a [`HeadlessGlyphBrushBuilder`](struct.HeadlessGlyphBrushBuilder.html).
+///
+/// # Example
+///
+/// ```no_run
+/// # extern crate gfx;
+/// # extern crate gfx_window_glutin;
+/// # extern crate glutin;
+/// extern crate gfx_glyph;
+/// use gfx_glyph::{HeadlessGlyphBrushBuilder, Section};
+/// # fn main() {
+///
+/// let arial: &[u8] = include_bytes!("../examples/Arial Unicode.ttf");
+/// let mut glyphs = HeadlessGlyphBrushBuilder::using_font(arial).build();
+///
+/// let section = Section {
+///     text: "Hello gfx_glyph",
+///     ..Section::default()
+/// };
+///
+/// let bounds = glyphs.pixel_bounds(section);
+/// # let _ = bounds;
+/// # let _ = glyphs;
+/// # }
+/// ```
+pub struct HeadlessGlyphBrush<'font> {
+    fonts: HashMap<FontId, rusttype::Font<'font>>,
+
+    // cache of section-layout hash -> computed glyphs, this avoid repeated glyph computation
+    // for identical layout/sections common to repeated frame rendering
+    calculate_glyph_cache: LinkedHashMap<u64, GlyphedSection<'font>>,
+
+    glyph_positioning_cache_size: usize,
+}
+
+impl<'font> HeadlessGlyphBrush<'font> {
+
+    /// Returns the pixel bounding box for the input section using a custom layout.
+    /// The box is a conservative whole number pixel rectangle that can contain the section.
+    ///
+    /// If the section is empty or would result in no drawn glyphs will return `None`
+    pub fn pixel_bounds_custom_layout<'a, S, L>(&mut self, section: S, custom_layout: &L)
+        -> Option<Rect<i32>>
+        where L: GlyphPositioner + Hash,
+              S: Into<Cow<'a, VariedSection<'a>>>,
+    {
+        let section = section.into();
+        let mut x = (0, 0);
+        let mut y = (0, 0);
+        let mut no_match = true;
+
+        let section_hash = self.cache_glyphs(section.borrow(), custom_layout);
+
+        for g in self.calculate_glyph_cache[&section_hash]
+            .glyphs.iter()
+            .flat_map(|&GlyphedSectionText(ref g, ..)| g.iter())
+        {
+            if let Some(Rect{ min, max }) = g.pixel_bounding_box() {
+                if no_match || min.x < x.0 { x.0 = min.x; }
+                if no_match || min.y < y.0 { y.0 = min.y; }
+                if no_match || max.x > x.1 { x.1 = max.x; }
+                if no_match || max.y > y.1 { y.1 = max.y; }
+
+                no_match = false;
+            }
+        }
+
+        if no_match { None }
+        else {
+            Some(Rect {
+                min: Point { x: x.0, y: y.0 },
+                max: Point { x: x.1, y: y.1 },
+            })
+        }
+    }
+
+    /// Returns the pixel bounding box for the input section. The box is a conservative
+    /// whole number pixel rectangle that can contain the section.
+    ///
+    /// If the section is empty or would result in no drawn glyphs will return `None`
+    pub fn pixel_bounds<'a, S>(&mut self, section: S)
+        -> Option<Rect<i32>>
+        where S: Into<Cow<'a, VariedSection<'a>>>,
+    {
+        let section = section.into();
+        let layout = section.layout;
+        self.pixel_bounds_custom_layout(section, &layout)
+    }
+
+    /// Returns the calculate_glyph_cache key for this sections glyphs
+    pub(crate) fn cache_glyphs<L>(&mut self, section: &VariedSection, layout: &L) -> u64
+        where L: GlyphPositioner,
+    {
+        let section_hash = hash(&(section, layout));
+
+        if self.calculate_glyph_cache.get_refresh(&section_hash).is_none() {
+            self.calculate_glyph_cache.insert(section_hash, GlyphedSection {
+                bounds: layout.bounds_rect(section),
+                glyphs: layout.calculate_glyphs(&self.fonts, section),
+                z: section.z,
+            });
+        }
+        else {
+            while self.calculate_glyph_cache.len() > self.glyph_positioning_cache_size {
+                self.calculate_glyph_cache.pop_front();
+            }
+        }
+
+        section_hash
+    }
+}
+
+
+/// Builder for a [`HeadlessGlyphBrush`](struct.HeadlessGlyphBrush.html).
+///
+/// # Example
+///
+/// ```no_run
+/// # extern crate gfx;
+/// # extern crate gfx_window_glutin;
+/// # extern crate glutin;
+/// extern crate gfx_glyph;
+/// use gfx_glyph::HeadlessGlyphBrushBuilder;
+/// # fn main() {
+///
+/// let arial: &[u8] = include_bytes!("../examples/Arial Unicode.ttf");
+/// let mut glyphs = HeadlessGlyphBrushBuilder::using_font(arial).build();
+/// # let _ = glyphs;
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct HeadlessGlyphBrushBuilder<'a> {
+    font_data: Vec<SharedBytes<'a>>,
+    glyph_positioning_cache_size: usize,
+}
+
+impl<'a> HeadlessGlyphBrushBuilder<'a> {
+    /// Specifies the default font data used to render glyphs.
+    /// Referenced with `FontId(0)`, which is default.
+    pub fn using_font<B: Into<SharedBytes<'a>>>(font_0_data: B) -> Self {
+        Self {
+            font_data: vec![font_0_data.into()],
+            glyph_positioning_cache_size: 50,
+        }
+    }
+
+    /// Adds additional fonts to the one added in [`using_font`](#method.using_font).
+    /// Returns a [`FontId`](struct.FontId.html) to reference this font.
+    pub fn add_font<B: Into<SharedBytes<'a>>>(&mut self, font_data: B) -> FontId {
+        self.font_data.push(font_data.into());
+        FontId(self.font_data.len() - 1)
+    }
+
+    /// Sets the max number of unique sections to cache positioning data. After processing
+    /// over this amount of sections oldest section positioning data will be evicted from the cache.
+    ///
+    /// Defaults to 50
+    pub fn glyph_positioning_cache_size(mut self, entries: usize) -> Self {
+        self.glyph_positioning_cache_size = entries;
+        self
+    }
+
+    /// Builds a `HeadlessGlyphBrush`
+    pub fn build(self) -> HeadlessGlyphBrush<'a> {
+        let fonts = self.font_data.into_iter().enumerate()
+            .map(|(idx, data)| (FontId(idx), font(data).unwrap()))
+            .collect();
+
+        let cache = LinkedHashMap::with_capacity(self.glyph_positioning_cache_size + 1);
+
+        HeadlessGlyphBrush {
+            fonts,
+            calculate_glyph_cache: cache,
+            glyph_positioning_cache_size: self.glyph_positioning_cache_size,
+        }
+    }
+}

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1,5 +1,6 @@
 use super::*;
-use linked_hash_map::LinkedHashMap;
+use std::mem;
+use std::sync::{Mutex, MutexGuard};
 
 /// Cut down version of a [`GlyphBrush`](struct.GlyphBrush.html) that can calculate pixel bounds,
 /// but is unable to actually render anything.
@@ -13,18 +14,20 @@ use linked_hash_map::LinkedHashMap;
 /// # extern crate gfx_window_glutin;
 /// # extern crate glutin;
 /// extern crate gfx_glyph;
-/// use gfx_glyph::{HeadlessGlyphBrushBuilder, Section};
+/// use gfx_glyph::{GlyphCalculator, HeadlessGlyphBrushBuilder, Section};
 /// # fn main() {
 ///
 /// let arial: &[u8] = include_bytes!("../examples/Arial Unicode.ttf");
-/// let mut glyphs = HeadlessGlyphBrushBuilder::using_font_bytes(arial).build();
+/// let glyphs = HeadlessGlyphBrushBuilder::using_font_bytes(arial).build();
 ///
 /// let section = Section {
 ///     text: "Hello gfx_glyph",
 ///     ..Section::default()
 /// };
 ///
-/// let bounds = glyphs.pixel_bounds(section);
+/// let mut scope = glyphs.cache_scope();
+///
+/// let bounds = scope.pixel_bounds(section);
 /// # let _ = bounds;
 /// # let _ = glyphs;
 /// # }
@@ -32,38 +35,69 @@ use linked_hash_map::LinkedHashMap;
 ///
 /// # Caching behaviour
 ///
-/// Calls to [`GlyphBrush::pixel_bounds`](#method.pixel_bounds),
-/// [`GlyphBrush::glyphs`](#method.glyphs) calculate the positioned glyphs for a section.
-/// This is cached so future calls to any of the methods for the same section are much
+/// Calls to [`HeadlessGlyphCacheGuard::pixel_bounds`](#method.pixel_bounds),
+/// [`HeadlessGlyphCacheGuard::glyphs`](#method.glyphs) calculate the positioned glyphs for a
+/// section. This is cached so future calls to any of the methods for the same section are much
 /// cheaper.
 ///
-/// Unlike a [`GlyphBrush`](struct.GlyphBrush.html) the cache has a maximum size and evicts
-/// older sections when full, this is because there is no concept of actually drawing the section
-/// to imply a section is no longer used.
-/// [`HeadlessGlyphBrushBuilder::glyph_positioning_cache_size`](struct.HeadlessGlyphBrushBuilder.html#method.glyph_positioning_cache_size)
-/// allows setting the maximum cache size.
+/// Unlike a [`GlyphBrush`](struct.GlyphBrush.html) there is no concept of actually drawing
+/// the section to imply a section is no longer used. Instead a `HeadlessGlyphCacheGuard`
+/// is created, that provides the calculation functionality. Dropping indicates the 'cache frame'
+/// is over, similar to when a `GlyphBrush` is draws. Any cached sections from previous 'frames'
+/// are invalidated.
 pub struct HeadlessGlyphBrush<'font> {
     fonts: HashMap<FontId, rusttype::Font<'font>>,
 
     // cache of section-layout hash -> computed glyphs, this avoid repeated glyph computation
     // for identical layout/sections common to repeated frame rendering
-    calculate_glyph_cache: LinkedHashMap<u64, GlyphedSection<'font>>,
-
-    glyph_positioning_cache_size: usize,
+    calculate_glyph_cache: Mutex<HashMap<u64, GlyphedSection<'font>>>,
 }
 
 impl<'font> HeadlessGlyphBrush<'font> {
+    pub fn cache_scope<'a>(&'a self) -> HeadlessGlyphCacheGuard<'a, 'font> {
+        HeadlessGlyphCacheGuard {
+            fonts: &self.fonts,
+            glyph_cache: self.calculate_glyph_cache.lock().unwrap(),
+            cached: HashSet::new(),
+        }
+    }
+}
 
-    /// Returns the pixel bounding box for the input section using a custom layout.
-    /// The box is a conservative whole number pixel rectangle that can contain the section.
-    ///
-    /// If the section is empty or would result in no drawn glyphs will return `None`
-    ///
-    /// Benefits from caching, see [caching behaviour](#caching-behaviour).
-    pub fn pixel_bounds_custom_layout<'a, S, L>(&mut self, section: S, custom_layout: &L)
-        -> Option<Rect<i32>>
-        where L: GlyphPositioner + Hash,
-              S: Into<Cow<'a, VariedSection<'a>>>,
+pub struct HeadlessGlyphCacheGuard<'brush, 'font: 'brush> {
+    fonts: &'brush HashMap<FontId, rusttype::Font<'font>>,
+    glyph_cache: MutexGuard<'brush, HashMap<u64, GlyphedSection<'font>>>,
+    cached: HashSet<u64>,
+}
+
+impl<'brush, 'font> HeadlessGlyphCacheGuard<'brush, 'font> {
+    /// Returns the calculate_glyph_cache key for this sections glyphs
+    fn cache_glyphs<L>(&mut self, section: &VariedSection, layout: &L) -> u64
+    where
+        L: GlyphPositioner,
+    {
+        let section_hash = hash(&(section, layout));
+
+        if let Entry::Vacant(entry) = self.glyph_cache.entry(section_hash) {
+            entry.insert(GlyphedSection {
+                bounds: layout.bounds_rect(section),
+                glyphs: layout.calculate_glyphs(self.fonts, section),
+                z: section.z,
+            });
+        }
+
+        section_hash
+    }
+}
+
+impl<'brush, 'font> GlyphCalculator<'font> for HeadlessGlyphCacheGuard<'brush, 'font> {
+    fn pixel_bounds_custom_layout<'a, S, L>(
+        &mut self,
+        section: S,
+        custom_layout: &L,
+    ) -> Option<Rect<i32>>
+    where
+        L: GlyphPositioner + Hash,
+        S: Into<Cow<'a, VariedSection<'a>>>,
     {
         let section = section.into();
         let mut x = (0, 0);
@@ -71,95 +105,64 @@ impl<'font> HeadlessGlyphBrush<'font> {
         let mut no_match = true;
 
         let section_hash = self.cache_glyphs(section.borrow(), custom_layout);
-
-        for g in self.calculate_glyph_cache[&section_hash]
-            .glyphs.iter()
+        self.cached.insert(section_hash);
+        for g in self.glyph_cache[&section_hash]
+            .glyphs
+            .iter()
             .flat_map(|&GlyphedSectionText(ref g, ..)| g.iter())
         {
-            if let Some(Rect{ min, max }) = g.pixel_bounding_box() {
-                if no_match || min.x < x.0 { x.0 = min.x; }
-                if no_match || min.y < y.0 { y.0 = min.y; }
-                if no_match || max.x > x.1 { x.1 = max.x; }
-                if no_match || max.y > y.1 { y.1 = max.y; }
+            if let Some(Rect { min, max }) = g.pixel_bounding_box() {
+                if no_match || min.x < x.0 {
+                    x.0 = min.x;
+                }
+                if no_match || min.y < y.0 {
+                    y.0 = min.y;
+                }
+                if no_match || max.x > x.1 {
+                    x.1 = max.x;
+                }
+                if no_match || max.y > y.1 {
+                    y.1 = max.y;
+                }
 
                 no_match = false;
             }
         }
 
-        if no_match { None }
+        if no_match {
+            None
+        }
         else {
-            Some(Rect {
-                min: Point { x: x.0, y: y.0 },
-                max: Point { x: x.1, y: y.1 },
-            })
+            Some(Rect { min: Point { x: x.0, y: y.0 }, max: Point { x: x.1, y: y.1 } })
         }
     }
 
-    /// Returns the pixel bounding box for the input section. The box is a conservative
-    /// whole number pixel rectangle that can contain the section.
-    ///
-    /// If the section is empty or would result in no drawn glyphs will return `None`
-    ///
-    /// Benefits from caching, see [caching behaviour](#caching-behaviour).
-    pub fn pixel_bounds<'a, S>(&mut self, section: S)
-        -> Option<Rect<i32>>
-        where S: Into<Cow<'a, VariedSection<'a>>>,
-    {
-        let section = section.into();
-        let layout = section.layout;
-        self.pixel_bounds_custom_layout(section, &layout)
-    }
-
-    /// Returns an iterator over the `PositionedGlyph`s of the given section with a custom layout.
-    ///
-    /// Benefits from caching, see [caching behaviour](#caching-behaviour).
-    pub fn glyphs_custom_layout<'a, 'b, S, L>(&'b mut self, section: S, custom_layout: &L)
-        -> PositionedGlyphIter<'b, 'font>
-        where L: GlyphPositioner + Hash,
-              S: Into<Cow<'a, VariedSection<'a>>>,
+    fn glyphs_custom_layout<'a, 'b, S, L>(
+        &'b mut self,
+        section: S,
+        custom_layout: &L,
+    ) -> PositionedGlyphIter<'b, 'font>
+    where
+        L: GlyphPositioner + Hash,
+        S: Into<Cow<'a, VariedSection<'a>>>,
     {
         let section = section.into();
         let section_hash = self.cache_glyphs(section.borrow(), custom_layout);
-        self.calculate_glyph_cache[&section_hash]
-            .glyphs.iter()
+        self.cached.insert(section_hash);
+        self.glyph_cache[&section_hash]
+            .glyphs
+            .iter()
             .flat_map(|&GlyphedSectionText(ref g, ..)| g.iter())
-    }
-
-    /// Returns an iterator over the `PositionedGlyph`s of the given section.
-    ///
-    /// Benefits from caching, see [caching behaviour](#caching-behaviour).
-    pub fn glyphs<'a, 'b, S>(&'b mut self, section: S)
-        -> PositionedGlyphIter<'b, 'font>
-        where S: Into<Cow<'a, VariedSection<'a>>>,
-    {
-        let section = section.into();
-        let layout = section.layout;
-        self.glyphs_custom_layout(section, &layout)
-    }
-
-    /// Returns the calculate_glyph_cache key for this sections glyphs
-    fn cache_glyphs<L>(&mut self, section: &VariedSection, layout: &L) -> u64
-        where L: GlyphPositioner,
-    {
-        let section_hash = hash(&(section, layout));
-
-        if self.calculate_glyph_cache.get_refresh(&section_hash).is_none() {
-            self.calculate_glyph_cache.insert(section_hash, GlyphedSection {
-                bounds: layout.bounds_rect(section),
-                glyphs: layout.calculate_glyphs(&self.fonts, section),
-                z: section.z,
-            });
-        }
-        else {
-            while self.calculate_glyph_cache.len() > self.glyph_positioning_cache_size {
-                self.calculate_glyph_cache.pop_front();
-            }
-        }
-
-        section_hash
     }
 }
 
+impl<'a, 'b> Drop for HeadlessGlyphCacheGuard<'a, 'b> {
+    fn drop(&mut self) {
+        let mut cached = HashSet::new();
+        mem::swap(&mut cached, &mut self.cached);
+        self.glyph_cache.retain(|key, _| cached.contains(key));
+    }
+}
 
 /// Builder for a [`HeadlessGlyphBrush`](struct.HeadlessGlyphBrush.html).
 ///
@@ -180,7 +183,6 @@ impl<'font> HeadlessGlyphBrush<'font> {
 /// ```
 pub struct HeadlessGlyphBrushBuilder<'a> {
     font_data: Vec<Font<'a>>,
-    glyph_positioning_cache_size: usize,
 }
 
 impl<'a> HeadlessGlyphBrushBuilder<'a> {
@@ -190,13 +192,25 @@ impl<'a> HeadlessGlyphBrushBuilder<'a> {
         Self::using_font(font(font_0_data).unwrap())
     }
 
+
+    pub fn using_fonts_bytes<B, V>(font_data: V) -> Self
+    where
+        B: Into<SharedBytes<'a>>,
+        V: Into<Vec<B>>,
+    {
+        Self::using_fonts(
+            font_data.into().into_iter().map(|data| font(data).unwrap()).collect::<Vec<_>>(),
+        )
+    }
+
     /// Specifies the default font used to render glyphs.
     /// Referenced with `FontId(0)`, which is default.
     pub fn using_font(font_0_data: Font<'a>) -> Self {
-        Self {
-            font_data: vec![font_0_data],
-            glyph_positioning_cache_size: 50,
-        }
+        Self { font_data: vec![font_0_data] }
+    }
+
+    pub fn using_fonts<V: Into<Vec<Font<'a>>>>(fonts: V) -> Self {
+        Self { font_data: fonts.into() }
     }
 
     /// Adds additional fonts to the one added in [`using_font`](#method.using_font) /
@@ -215,27 +229,17 @@ impl<'a> HeadlessGlyphBrushBuilder<'a> {
         FontId(self.font_data.len() - 1)
     }
 
-    /// Sets the max number of unique sections to cache positioning data. After processing
-    /// over this amount of sections oldest section positioning data will be evicted from the cache.
-    ///
-    /// Defaults to 50
-    pub fn glyph_positioning_cache_size(mut self, entries: usize) -> Self {
-        self.glyph_positioning_cache_size = entries;
-        self
-    }
-
     /// Builds a `HeadlessGlyphBrush`
     pub fn build(self) -> HeadlessGlyphBrush<'a> {
-        let fonts = self.font_data.into_iter().enumerate()
+        let fonts = self.font_data
+            .into_iter()
+            .enumerate()
             .map(|(idx, data)| (FontId(idx), data))
             .collect();
 
-        let cache = LinkedHashMap::with_capacity(self.glyph_positioning_cache_size + 1);
-
         HeadlessGlyphBrush {
             fonts,
-            calculate_glyph_cache: cache,
-            glyph_positioning_cache_size: self.glyph_positioning_cache_size,
+            calculate_glyph_cache: Mutex::new(HashMap::new()),
         }
     }
 }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -138,7 +138,7 @@ impl<'font> HeadlessGlyphBrush<'font> {
     }
 
     /// Returns the calculate_glyph_cache key for this sections glyphs
-    pub(crate) fn cache_glyphs<L>(&mut self, section: &VariedSection, layout: &L) -> u64
+    fn cache_glyphs<L>(&mut self, section: &VariedSection, layout: &L) -> u64
         where L: GlyphPositioner,
     {
         let section_hash = hash(&(section, layout));

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -158,14 +158,6 @@ impl<'font> HeadlessGlyphBrush<'font> {
 
         section_hash
     }
-
-    /// Invalidates any cached computations.
-    ///
-    /// This is useful if environment values outside of passed section/layout data
-    /// has changed, e.g. screen resolution.
-    pub fn clear_cache(&mut self) {
-        self.calculate_glyph_cache.clear();
-    }
 }
 
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -158,6 +158,14 @@ impl<'font> HeadlessGlyphBrush<'font> {
 
         section_hash
     }
+
+    /// Invalidates any cached computations.
+    ///
+    /// This is useful if environment values outside of passed section/layout data
+    /// has changed, e.g. screen resolution.
+    pub fn clear_cache(&mut self) {
+        self.calculate_glyph_cache.clear();
+    }
 }
 
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::fmt;
 use std::mem;
 use std::sync::{Mutex, MutexGuard};
 
@@ -53,6 +54,12 @@ pub struct HeadlessGlyphBrush<'font> {
     calculate_glyph_cache: Mutex<HashMap<u64, GlyphedSection<'font>>>,
 }
 
+impl<'font> fmt::Debug for HeadlessGlyphBrush<'font> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "HeadlessGlyphBrush")
+    }
+}
+
 impl<'font> HeadlessGlyphBrush<'font> {
     pub fn cache_scope<'a>(&'a self) -> HeadlessGlyphCacheGuard<'a, 'font> {
         HeadlessGlyphCacheGuard {
@@ -86,6 +93,12 @@ impl<'brush, 'font> HeadlessGlyphCacheGuard<'brush, 'font> {
         }
 
         section_hash
+    }
+}
+
+impl<'brush, 'font> fmt::Debug for HeadlessGlyphCacheGuard<'brush, 'font> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "HeadlessGlyphCacheGuard")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ mod pipe;
 mod builder;
 #[macro_use]
 mod trace;
+mod headless;
 
 use gfx::traits::FactoryExt;
 use rusttype::{FontCollection, point, vector};
@@ -89,6 +90,7 @@ pub use section::*;
 pub use layout::*;
 pub use linebreak::*;
 pub use builder::*;
+pub use headless::*;
 
 /// Aliased type to allow lib usage without declaring underlying **rusttype** lib
 pub type Font<'a> = rusttype::Font<'a>;
@@ -348,7 +350,6 @@ impl<'font, R: gfx::Resources, F: gfx::Factory<R>> GlyphBrush<'font, R, F> {
     fn cache_glyphs<L>(&mut self, section: &VariedSection, layout: &L) -> u64
         where L: GlyphPositioner,
     {
-        let start = Instant::now();
         let section_hash = hash(&(section, layout));
 
         if self.cache_glyph_positioning {
@@ -367,8 +368,6 @@ impl<'font, R: gfx::Resources, F: gfx::Factory<R>> GlyphBrush<'font, R, F> {
                 z: section.z,
             });
         }
-        trace!("layout.calculate_glyphs in {:.3}ms",
-            f64::from(start.elapsed().subsec_nanos()) / 1_000_000_f64);
         section_hash
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ mod builder;
 mod trace;
 mod headless;
 mod glyph_calculator;
+mod owned_section;
 
 use gfx::traits::FactoryExt;
 use rusttype::{FontCollection, point, vector};
@@ -81,8 +82,7 @@ use std::borrow::{Cow, Borrow};
 use std::error::Error;
 use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry;
-use std::iter;
-use std::slice;
+use std::{fmt, slice, iter};
 use std::time::*;
 use pipe::*;
 use log::LogLevel;
@@ -93,6 +93,7 @@ pub use linebreak::*;
 pub use builder::*;
 pub use headless::*;
 pub use glyph_calculator::*;
+pub use owned_section::*;
 
 /// Aliased type to allow lib usage without declaring underlying **rusttype** lib
 pub type Font<'a> = rusttype::Font<'a>;
@@ -224,6 +225,12 @@ pub struct GlyphBrush<'font, R: gfx::Resources, F: gfx::Factory<R>> {
     cache_glyph_drawing: bool,
 
     depth_test: gfx::state::Depth,
+}
+
+impl<'font, R: gfx::Resources, F: gfx::Factory<R>> fmt::Debug for GlyphBrush<'font, R, F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "GlyphBrush")
+    }
 }
 
 impl<'font, R: gfx::Resources, F: gfx::Factory<R>> GlyphCalculator<'font> for GlyphBrush<'font, R, F> {

--- a/src/owned_section.rs
+++ b/src/owned_section.rs
@@ -1,0 +1,91 @@
+use super::*;
+use std::f32;
+
+#[derive(Debug, Clone)]
+pub struct OwnedVariedSection {
+    /// Position on screen to render text, in pixels from top-left. Defaults to (0, 0).
+    pub screen_position: (f32, f32),
+    /// Max (width, height) bounds, in pixels from top-left. Defaults to unbounded.
+    pub bounds: (f32, f32),
+    /// Z values for use in depth testing. Defaults to 0.0
+    pub z: f32,
+    /// Built in layout, can be overridden with custom layout logic
+    /// see [`queue_custom_layout`](struct.GlyphBrush.html#method.queue_custom_layout)
+    pub layout: Layout<BuiltInLineBreaker>,
+    /// Text to render, rendered next to one another according the layout.
+    pub text: Vec<OwnedSectionText>,
+}
+
+impl Default for OwnedVariedSection {
+    fn default() -> Self {
+        Self {
+            screen_position: (0.0, 0.0),
+            bounds: (f32::INFINITY, f32::INFINITY),
+            z: 0.0,
+            layout: Layout::default(),
+            text: vec![],
+        }
+    }
+}
+
+impl OwnedVariedSection {
+    pub fn to_borrowed<'a>(&'a self) -> VariedSection<'a> {
+        VariedSection {
+            screen_position: self.screen_position,
+            bounds: self.bounds,
+            z: self.z,
+            layout: self.layout,
+            text: self.text.iter().map(|t| t.into()).collect(),
+        }
+    }
+}
+
+impl<'a> From<&'a OwnedVariedSection> for VariedSection<'a> {
+    fn from(owned: &'a OwnedVariedSection) -> Self {
+        owned.to_borrowed()
+    }
+}
+
+impl<'a> From<&'a OwnedVariedSection> for Cow<'a, VariedSection<'a>> {
+    fn from(owned: &'a OwnedVariedSection) -> Self {
+        Cow::Owned(owned.to_borrowed())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OwnedSectionText {
+    /// Text to render
+    pub text: String,
+    /// Position on screen to render text, in pixels from top-left. Defaults to (0, 0).
+    pub scale: Scale,
+    /// Rgba color of rendered text. Defaults to black.
+    pub color: [f32; 4],
+    /// Font id to use for this section.
+    ///
+    /// It must be known to the `GlyphBrush` it is being used with,
+    /// either `FontId::default()` or the return of
+    /// [`add_font`](struct.GlyphBrushBuilder.html#method.add_font).
+    pub font_id: FontId,
+}
+
+impl Default for OwnedSectionText {
+    fn default() -> Self {
+        Self {
+            text: String::new(),
+            scale: Scale::uniform(16.0),
+            color: [0.0, 0.0, 0.0, 1.0],
+            font_id: FontId::default(),
+        }
+    }
+}
+
+impl<'a> From<&'a OwnedSectionText> for SectionText<'a> {
+    fn from(owned: &'a OwnedSectionText) -> Self {
+        Self {
+            text: owned.text.as_str(),
+            scale: owned.scale,
+            color: owned.color,
+            font_id: owned.font_id,
+        }
+    }
+}

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -37,7 +37,7 @@ gfx_defines!{
 
 gfx_pipeline_base!( glyph_pipe {
     vbuf: VertexBuffer<GlyphVertex>,
-    font_tex: TextureSampler<TexFormView>,
+    font_tex: gfx::pso::resource::TextureSampler<TexFormView>,
     transform: Global<[[f32; 4]; 4]>,
     out: RawRenderTarget,
     out_depth: RawDepthTarget,

--- a/src/section.rs
+++ b/src/section.rs
@@ -1,5 +1,6 @@
 use super::*;
 use std::f32;
+use super::owned_section::*;
 
 /// An object that contains all the info to render a varied section of text. That is one including
 /// many parts with differing fonts/scales/colors bowing to a single layout.
@@ -91,6 +92,18 @@ impl<'a> Hash for VariedSection<'a> {
     }
 }
 
+impl<'a> VariedSection<'a> {
+    pub fn to_owned(&self) -> OwnedVariedSection {
+        OwnedVariedSection {
+            screen_position: self.screen_position,
+            bounds: self.bounds,
+            z: self.z,
+            layout: self.layout,
+            text: self.text.iter().map(|t| t.to_owned()).collect(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct SectionText<'a> {
     /// Text to render
@@ -139,6 +152,17 @@ impl<'a> Hash for SectionText<'a> {
         ];
 
         (text, font_id, ord_floats).hash(state);
+    }
+}
+
+impl<'a> SectionText<'a> {
+    pub fn to_owned(&self) -> OwnedSectionText {
+        OwnedSectionText {
+            text: self.text.to_owned(),
+            scale: self.scale,
+            color: self.color,
+            font_id: self.font_id,
+        }
     }
 }
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,4 +1,4 @@
-/// Returns a `String` backtrace from after the 'gfx_glyph' bits outwards
+/// Returns a `String` backtrace from just after the `gfx_glyph` bits outwards
 macro_rules! outer_backtrace {
     () => {{
         use std::fmt::Write;


### PR DESCRIPTION
With my rusttype changes now available in 0.3 I can merge my work for the next gfx_glyph version.

* `HeadlessGlyphBrush` allows font calculations / pixel bounds etc without actually being able to draw anything, or the need for gfx objects. Using a scoped caching system.
* Cache / font lifetime changes made to rusttype allow removing the `.standalone()` calls when adding glyphs to the gpu-cache. This and other rusttype optimisations can result in up to ~25% faster worst case performance (worst case being no position/draw caching / text changes every frame).
* `OwnedVariedSection` & `OwnedSectionText` to help some edge cases where borrowing is annoying.
* Simple `Debug` implementations to allow end users to derive more easily.

_0.6.4 -> 0.7.0:_

```
name                                                    control.stdout ns/iter  change.stdout ns/iter  diff ns/iter   diff %  speedup
no_cache_render_100_small_sections_fully                28,888,959              20,903,851               -7,985,108  -27.64%   x 1.38 
no_cache_render_1_large_section_partially               5,967,363               5,876,948                   -90,415   -1.52%   x 1.02 
no_cache_render_3_medium_sections_fully                 15,981,615              14,046,550               -1,935,065  -12.11%   x 1.14 
render_100_small_sections_fully                         37,824                  37,726                          -98   -0.26%   x 1.00 
render_1_large_section_partially                        7,820                   7,880                            60    0.77%   x 0.99 
render_3_medium_sections_fully                          2,523                   2,482                           -41   -1.63%   x 1.02
```