### PR TITLE
Fix #20: Use rusttype 0.5.2 glyph padding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme="README.md"
 
 [dependencies]
 log = "0.4"
-rusttype = { path = "../rusttype", features = ["gpu_cache"] }
+rusttype = { version = "0.5.2", features = ["gpu_cache"] }
 gfx = "0.17"
 gfx_core = "0.8"
 unicode-normalization = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme="README.md"
 
 [dependencies]
 log = "0.4"
-rusttype = { version = "0.5.1", features = ["gpu_cache"] }
+rusttype = { path = "../rusttype", features = ["gpu_cache"] }
 gfx = "0.17"
 gfx_core = "0.8"
 unicode-normalization = "0.1"

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -14,7 +14,6 @@ extern crate gfx_glyph;
 extern crate gfx_window_glutin;
 extern crate glutin;
 extern crate spin_sleep;
-extern crate time;
 
 use cgmath::{Matrix4, Rad, Transform};
 use gfx::{format, Device};
@@ -27,13 +26,15 @@ use std::io::Write;
 fn main() {
     env_logger::init();
 
-    // winit wayland is currently still wip
-    if cfg!(target_os = "linux") && env::var("WINIT_UNIX_BACKEND").is_err() {
-        env::set_var("WINIT_UNIX_BACKEND", "x11");
-    }
-    // disables vsync sometimes on x11
-    if env::var("vblank_mode").is_err() {
-        env::set_var("vblank_mode", "0");
+    if cfg!(target_os = "linux") {
+        // winit wayland is currently still wip
+        if env::var("WINIT_UNIX_BACKEND").is_err() {
+            env::set_var("WINIT_UNIX_BACKEND", "x11");
+        }
+        // disables vsync sometimes on x11
+        if env::var("vblank_mode").is_err() {
+            env::set_var("vblank_mode", "0");
+        }
     }
 
     if cfg!(debug_assertions) && env::var("yes_i_really_want_debug_mode").is_err() {
@@ -66,11 +67,11 @@ fn main() {
     let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();
 
     let mut running = true;
-    let mut font_size = gfx_glyph::Scale::uniform(86.0);
+    let mut font_size = gfx_glyph::Scale::uniform(18.0 * window.hidpi_factor());
     let mut zoom: f32 = 1.0;
-    let mut angle = 0.28 * PI32;
+    let mut angle = 0.0;
     let mut ctrl = false;
-    let mut loop_helper = spin_sleep::LoopHelper::builder().build_with_target_rate(200.0);
+    let mut loop_helper = spin_sleep::LoopHelper::builder().build_with_target_rate(250.0);
 
     while running {
         loop_helper.loop_start();
@@ -158,11 +159,10 @@ fn main() {
                                 size *= 4.0 / 5.0
                             };
                             size = size.max(1.0);
-                            font_size =
-                                gfx_glyph::Scale::uniform((size * window.hidpi_factor()).round());
+                            font_size = gfx_glyph::Scale::uniform(size * window.hidpi_factor());
                             if (font_size.x - old_size).abs() > 1e-2 {
                                 print!("\r                            \r");
-                                print!("font-size -> {}", font_size.x);
+                                print!("font-size -> {:.1}", font_size.x);
                                 io::stdout().flush().ok().unwrap();
                             }
                         }
@@ -171,8 +171,6 @@ fn main() {
                 }
             }
         });
-
-        angle -= 0.0000001 * ::time::precise_time_s() as f32;
 
         encoder.clear(&main_color, [0.02, 0.02, 0.02, 1.0]);
 

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -5,10 +5,10 @@ extern crate gfx_window_glutin;
 extern crate glutin;
 extern crate spin_sleep;
 
-use glutin::GlContext;
 use gfx::{format, Device};
-use std::env;
 use gfx_glyph::*;
+use glutin::GlContext;
+use std::env;
 
 fn main() {
     env_logger::init();

--- a/examples/varied.rs
+++ b/examples/varied.rs
@@ -10,10 +10,10 @@ extern crate gfx_window_glutin;
 extern crate glutin;
 extern crate spin_sleep;
 
-use glutin::GlContext;
 use gfx::{format, Device};
-use std::env;
 use gfx_glyph::*;
+use glutin::GlContext;
+use std::env;
 
 fn main() {
     env_logger::init();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -193,7 +193,6 @@ impl<'a> GlyphBrushBuilder<'a> {
                 ..CacheBuilder::default()
             }.build(),
             font_cache_tex,
-            font_cache_tex_zeroed: true,
 
             factory,
             draw_cache: None,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -32,6 +32,7 @@ pub struct GlyphBrushBuilder<'a> {
     cache_glyph_positioning: bool,
     cache_glyph_drawing: bool,
     depth_test: gfx::state::Depth,
+    texture_filter_method: texture::FilterMethod,
 }
 
 impl<'a> GlyphBrushBuilder<'a> {
@@ -70,6 +71,7 @@ impl<'a> GlyphBrushBuilder<'a> {
             cache_glyph_positioning: true,
             cache_glyph_drawing: true,
             depth_test: gfx::preset::depth::PASS_TEST,
+            texture_filter_method: texture::FilterMethod::Bilinear,
         }
     }
 
@@ -77,7 +79,8 @@ impl<'a> GlyphBrushBuilder<'a> {
     /// [`using_font_bytes`](#method.using_font_bytes).
     /// Returns a [`FontId`](struct.FontId.html) to reference this font.
     pub fn add_font_bytes<B: Into<SharedBytes<'a>>>(&mut self, font_data: B) -> FontId {
-        self.font_data.push(Font::from_bytes(font_data.into()).unwrap());
+        self.font_data
+            .push(Font::from_bytes(font_data.into()).unwrap());
         FontId(self.font_data.len() - 1)
     }
 
@@ -170,6 +173,28 @@ impl<'a> GlyphBrushBuilder<'a> {
         self
     }
 
+    /// Sets the texture filtering method.
+    ///
+    /// Defaults to `Bilinear`
+    ///
+    /// # Example
+    /// ```no_run
+    /// # extern crate gfx;
+    /// # extern crate gfx_glyph;
+    /// # use gfx_glyph::GlyphBrushBuilder;
+    /// # fn main() {
+    /// # let some_font: &[u8] = include_bytes!("../examples/DejaVuSans.ttf");
+    /// GlyphBrushBuilder::using_font_bytes(some_font)
+    ///     .texture_filter_method(gfx::texture::FilterMethod::Scale)
+    ///     // ...
+    /// # ;
+    /// # }
+    /// ```
+    pub fn texture_filter_method(mut self, filter_method: texture::FilterMethod) -> Self {
+        self.texture_filter_method = filter_method;
+        self
+    }
+
     /// Builds a `GlyphBrush` using the input gfx factory
     pub fn build<R, F>(self, mut factory: F) -> GlyphBrush<'a, R, F>
     where
@@ -193,6 +218,7 @@ impl<'a> GlyphBrushBuilder<'a> {
                 ..CacheBuilder::default()
             }.build(),
             font_cache_tex,
+            texture_filter_method: self.texture_filter_method,
 
             factory,
             draw_cache: None,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -185,13 +185,15 @@ impl<'a> GlyphBrushBuilder<'a> {
                 .enumerate()
                 .map(|(idx, data)| (FontId(idx), data))
                 .collect(),
-            font_cache: Cache::new(
-                cache_width,
-                cache_height,
-                self.gpu_cache_scale_tolerance,
-                self.gpu_cache_position_tolerance,
-            ),
+            font_cache: CacheBuilder {
+                width: cache_width,
+                height: cache_height,
+                scale_tolerance: self.gpu_cache_scale_tolerance,
+                position_tolerance: self.gpu_cache_position_tolerance,
+                ..CacheBuilder::default()
+            }.build(),
             font_cache_tex,
+            font_cache_tex_zeroed: true,
 
             factory,
             draw_cache: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,26 +79,25 @@ mod owned_section;
 #[cfg(feature = "performance_stats")]
 mod performance_stats;
 
-use gfx_core::memory::Typed;
+pub use builder::*;
 use gfx::{format, handle, texture};
 use gfx::traits::FactoryExt;
+use gfx_core::memory::Typed;
+pub use glyph_calculator::*;
+pub use layout::*;
+pub use linebreak::*;
+pub use owned_section::*;
 use pipe::*;
 use rusttype::{point, vector};
 use rusttype::gpu_cache::Cache;
-use std::hash::{Hash, Hasher};
-use std::i32;
+pub use section::*;
+use std::{fmt, iter, slice};
 use std::borrow::{Borrow, Cow};
-use std::error::Error;
 use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry;
-use std::{fmt, iter, slice};
-
-pub use section::*;
-pub use layout::*;
-pub use linebreak::*;
-pub use builder::*;
-pub use glyph_calculator::*;
-pub use owned_section::*;
+use std::error::Error;
+use std::hash::{Hash, Hasher};
+use std::i32;
 
 /// Aliased type to allow lib usage without declaring underlying **rusttype** lib
 pub type Font<'a> = rusttype::Font<'a>;
@@ -577,10 +576,13 @@ impl<'font, R: gfx::Resources, F: gfx::Factory<R>> GlyphBrush<'font, R, F> {
             else {
                 DrawnGlyphBrush {
                     pipe_data: {
-                        let sampler = self.factory.create_sampler(texture::SamplerInfo::new(
-                            texture::FilterMethod::Scale,
-                            texture::WrapMode::Clamp,
-                        ));
+                        let sampler = self.factory.create_sampler(texture::SamplerInfo {
+                            border: [0.0, 0.0, 0.0, 0.0].into(),
+                            ..texture::SamplerInfo::new(
+                                texture::FilterMethod::Bilinear,
+                                texture::WrapMode::Border,
+                            )
+                        });
                         glyph_pipe::Data {
                             vbuf,
                             font_tex: (self.font_cache_tex.1.clone(), sampler),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,7 @@ pub struct GlyphBrush<'font, R: gfx::Resources, F: gfx::Factory<R>> {
         gfx::handle::Texture<R, TexSurface>,
         gfx_core::handle::ShaderResourceView<R, f32>,
     ),
+    texture_filter_method: texture::FilterMethod,
     factory: F,
     draw_cache: Option<DrawnGlyphBrush<R>>,
 
@@ -578,13 +579,10 @@ impl<'font, R: gfx::Resources, F: gfx::Factory<R>> GlyphBrush<'font, R, F> {
             else {
                 DrawnGlyphBrush {
                     pipe_data: {
-                        let sampler = self.factory.create_sampler(texture::SamplerInfo {
-                            border: [0.0, 0.0, 0.0, 0.0].into(),
-                            ..texture::SamplerInfo::new(
-                                texture::FilterMethod::Bilinear,
-                                texture::WrapMode::Border,
-                            )
-                        });
+                        let sampler = self.factory.create_sampler(texture::SamplerInfo::new(
+                            self.texture_filter_method,
+                            texture::WrapMode::Clamp,
+                        ));
                         glyph_pipe::Data {
                             vbuf,
                             font_tex: (self.font_cache_tex.1.clone(), sampler),


### PR DESCRIPTION
This pr resolves #20 by making use of https://github.com/redox-os/rusttype/pull/104 to eliminate texture bleed from interpolated texture coordinates, and by adding default bilinear texture filtering _(configurable)_.
