### PR TITLE
Make cache frame based

### DIFF
--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -114,6 +114,7 @@ fn main() {
         glyph_brush
             .draw_queued(&mut encoder, &main_color, &main_depth)
             .expect("draw");
+        glyph_brush.end_frame();
 
         encoder.flush(&mut device);
         window.swap_buffers().unwrap();

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -252,6 +252,7 @@ fn main() {
         glyph_brush
             .draw_queued_with_transform(transform.into(), &mut encoder, &main_color, &main_depth)
             .expect("draw");
+        glyph_brush.end_frame();
 
         encoder.flush(&mut device);
         window.swap_buffers().unwrap();

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -138,6 +138,7 @@ fn main() {
         glyph_brush
             .draw_queued(&mut encoder, &main_color, &main_depth)
             .expect("draw");
+        glyph_brush.end_frame();
 
         encoder.flush(&mut device);
         window.swap_buffers().unwrap();

--- a/examples/varied.rs
+++ b/examples/varied.rs
@@ -147,6 +147,7 @@ fn main() {
         glyph_brush
             .draw_queued(&mut encoder, &main_color, &main_depth)
             .expect("draw");
+        glyph_brush.end_frame();
 
         encoder.flush(&mut device);
         window.swap_buffers().unwrap();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -223,6 +223,7 @@ impl<'a> GlyphBrushBuilder<'a> {
             factory,
             draw_cache: None,
             section_buffer: Vec::new(),
+            section_buffer_index: 0,
             calculate_glyph_cache: HashMap::new(),
             keep_in_cache: HashSet::new(),
 


### PR DESCRIPTION
In Amethyst we have a need to intersperse text drawing with other GPU actions such as drawing other UI images.  This is necessary in order to preserve Z-ordering for our UI.  However currently when we do this we are not able to take advantage of the caching behavior of this library.

So this PR alters the API to use a "frame based cache" rather than "draw call based cache".  This does mean that users of the library have to explicitly signal the end of the frame, however for our use case this will make the crate much more efficient.