### PR TITLE
Changed misleading variable name in examples.

### DIFF
--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -37,7 +37,7 @@ fn main() {
         .with_title(title)
         .with_dimensions(700, 320);
     let context = glutin::ContextBuilder::new();
-    let (window, mut device, mut factory, mut main_color, mut main_depth) =
+    let (window, mut device, mut factory, mut main_view, mut main_depth) =
         gfx_window_glutin::init::<format::Srgba8, format::Depth>(
             window_builder,
             context,
@@ -75,17 +75,17 @@ fn main() {
                     | WindowEvent::Closed => running = false,
                     WindowEvent::Resized(width, height) => {
                         window.resize(width, height);
-                        gfx_window_glutin::update_views(&window, &mut main_color, &mut main_depth);
+                        gfx_window_glutin::update_views(&window, &mut main_view, &mut main_depth);
                     }
                     _ => {}
                 }
             }
         });
 
-        encoder.clear(&main_color, [0.02, 0.02, 0.02, 1.0]);
+        encoder.clear(&main_view, [0.02, 0.02, 0.02, 1.0]);
         encoder.clear_depth(&main_depth, 1.0);
 
-        let (width, height, ..) = main_color.get_dimensions();
+        let (width, height, ..) = main_view.get_dimensions();
         let (width, height) = (f32::from(width), f32::from(height));
 
         // first section is queued, and therefore drawn, first with lower z
@@ -112,7 +112,7 @@ fn main() {
         });
 
         glyph_brush
-            .draw_queued(&mut encoder, &main_color, &main_depth)
+            .draw_queued(&mut encoder, &main_view, &main_depth)
             .expect("draw");
 
         encoder.flush(&mut device);

--- a/examples/paragraph.rs
+++ b/examples/paragraph.rs
@@ -50,7 +50,7 @@ fn main() {
         .with_title(title)
         .with_dimensions(1024, 576);
     let context = glutin::ContextBuilder::new();
-    let (window, mut device, mut factory, mut main_color, mut main_depth) =
+    let (window, mut device, mut factory, mut main_view, mut main_depth) =
         gfx_window_glutin::init::<format::Srgba8, format::DepthStencil>(
             window_builder,
             context,
@@ -111,7 +111,7 @@ fn main() {
                     },
                     WindowEvent::Resized(width, height) => {
                         window.resize(width, height);
-                        gfx_window_glutin::update_views(&window, &mut main_color, &mut main_depth);
+                        gfx_window_glutin::update_views(&window, &mut main_view, &mut main_depth);
                     }
                     WindowEvent::MouseWheel {
                         delta: MouseScrollDelta::LineDelta(_, y),
@@ -172,9 +172,9 @@ fn main() {
             }
         });
 
-        encoder.clear(&main_color, [0.02, 0.02, 0.02, 1.0]);
+        encoder.clear(&main_view, [0.02, 0.02, 0.02, 1.0]);
 
-        let (width, height, ..) = main_color.get_dimensions();
+        let (width, height, ..) = main_view.get_dimensions();
         let (width, height) = (f32::from(width), f32::from(height));
         let scale = font_size;
 
@@ -220,7 +220,7 @@ fn main() {
         });
 
         // Note: Can be drawn simply with the below, when transforms are not needed:
-        // `glyph_brush.draw_queued(&mut encoder, &main_color, &main_depth).expect("draw");`
+        // `glyph_brush.draw_queued(&mut encoder, &main_view, &main_depth).expect("draw");`
 
         // Here an example transform is used as a cheap zoom out (controlled with ctrl-scroll)
         let transform_zoom = Matrix4::from_scale(zoom);
@@ -250,7 +250,7 @@ fn main() {
         // is essentially free as the vertices are reused & gpu cache updating interaction
         // can be skipped.
         glyph_brush
-            .draw_queued_with_transform(transform.into(), &mut encoder, &main_color, &main_depth)
+            .draw_queued_with_transform(transform.into(), &mut encoder, &main_view, &main_depth)
             .expect("draw");
 
         encoder.flush(&mut device);

--- a/examples/performance.rs
+++ b/examples/performance.rs
@@ -37,7 +37,7 @@ fn main() {
         .with_title(title)
         .with_dimensions(1024, 576);
     let context = glutin::ContextBuilder::new().with_vsync(false);
-    let (window, mut device, mut factory, mut main_color, mut main_depth) =
+    let (window, mut device, mut factory, mut main_view, mut main_depth) =
         gfx_window_glutin::init::<format::Srgba8, format::Depth>(
             window_builder,
             context,
@@ -85,7 +85,7 @@ fn main() {
                     },
                     WindowEvent::Resized(width, height) => {
                         window.resize(width, height);
-                        gfx_window_glutin::update_views(&window, &mut main_color, &mut main_depth);
+                        gfx_window_glutin::update_views(&window, &mut main_view, &mut main_depth);
                     }
                     WindowEvent::MouseWheel {
                         delta: MouseScrollDelta::LineDelta(_, y),
@@ -107,9 +107,9 @@ fn main() {
             }
         });
 
-        encoder.clear(&main_color, [0.02, 0.02, 0.02, 1.0]);
+        encoder.clear(&main_view, [0.02, 0.02, 0.02, 1.0]);
 
-        let (width, height, ..) = main_color.get_dimensions();
+        let (width, height, ..) = main_view.get_dimensions();
         let (width, height) = (f32::from(width), f32::from(height));
 
         // The section is all the info needed for the glyph brush to render a 'section' of text
@@ -136,7 +136,7 @@ fn main() {
         // is essentially free as the vertices are reused &  gpu cache updating interaction
         // can be skipped.
         glyph_brush
-            .draw_queued(&mut encoder, &main_color, &main_depth)
+            .draw_queued(&mut encoder, &main_view, &main_depth)
             .expect("draw");
 
         encoder.flush(&mut device);

--- a/examples/varied.rs
+++ b/examples/varied.rs
@@ -42,7 +42,7 @@ fn main() {
         .with_title(title)
         .with_dimensions(1024, 576);
     let context = glutin::ContextBuilder::new().with_vsync(false);
-    let (window, mut device, mut factory, mut main_color, mut main_depth) =
+    let (window, mut device, mut factory, mut main_view, mut main_depth) =
         gfx_window_glutin::init::<format::Srgba8, format::Depth>(
             window_builder,
             context,
@@ -81,16 +81,16 @@ fn main() {
                     | WindowEvent::Closed => running = false,
                     WindowEvent::Resized(width, height) => {
                         window.resize(width, height);
-                        gfx_window_glutin::update_views(&window, &mut main_color, &mut main_depth);
+                        gfx_window_glutin::update_views(&window, &mut main_view, &mut main_depth);
                     }
                     _ => {}
                 }
             }
         });
 
-        encoder.clear(&main_color, [0.02, 0.02, 0.02, 1.0]);
+        encoder.clear(&main_view, [0.02, 0.02, 0.02, 1.0]);
 
-        let (width, height, ..) = main_color.get_dimensions();
+        let (width, height, ..) = main_view.get_dimensions();
         let (width, height) = (f32::from(width), f32::from(height));
 
         glyph_brush.queue(VariedSection {
@@ -145,7 +145,7 @@ fn main() {
         });
 
         glyph_brush
-            .draw_queued(&mut encoder, &main_color, &main_depth)
+            .draw_queued(&mut encoder, &main_view, &main_depth)
             .expect("draw");
 
         encoder.flush(&mut device);


### PR DESCRIPTION
`encoder.clear(&main_color, [0.02, 0.02, 0.02, 1.0]);` threw me for a loop; `main_view` feels like a better name for a `RenderTargetView`.