### PR TITLE
 Allow first word of a line to break width bounds 

### DIFF
--- a/src/layout/builtin.rs
+++ b/src/layout/builtin.rs
@@ -677,13 +677,19 @@ mod layout_test {
             },
         );
 
-        assert_glyph_order!(glyphs, "The");
+        assert_glyph_order!(glyphs, "Themoonlight");
 
         let y_ords: HashSet<OrderedFloat<f32>> = glyphs
             .iter()
             .map(|g| OrderedFloat(g.0.position().y))
             .collect();
 
-        assert_eq!(y_ords.len(), 1, "Y ords: {:?}", y_ords);
+        assert_eq!(y_ords.len(), 2, "Y ords: {:?}", y_ords);
+
+        let first_line_y = y_ords.iter().min().unwrap();
+        let second_line_y = y_ords.iter().max().unwrap();
+
+        assert_relative_eq!(glyphs[0].0.position().y, first_line_y);
+        assert_relative_eq!(glyphs[3].0.position().y, second_line_y);
     }
 }

--- a/src/layout/lines.rs
+++ b/src/layout/lines.rs
@@ -74,6 +74,11 @@ impl<'font> Line<'font> {
 }
 
 /// `Line` iterator.
+///
+/// Will iterator through `Word` until the next word would break the `width_bound`.
+///
+/// Note: Will always have at least one word, if possible, even if the word itself
+/// breaks the `width_bound`.
 pub(crate) struct Lines<'a, 'b, 'font: 'a + 'b, L: LineBreaker> {
     pub(crate) words: Peekable<Words<'a, 'b, 'font, L>>,
     pub(crate) width_bound: f32,
@@ -95,7 +100,8 @@ impl<'a, 'b, 'font, L: LineBreaker> Iterator for Lines<'a, 'b, 'font, L> {
         loop {
             if let Some(word) = self.words.peek() {
                 let word_max_x = word.bounds.map(|b| b.max.x).unwrap_or(word.layout_width);
-                if (caret.x + word_max_x).ceil() > self.width_bound {
+                // only if `progressed` means the first word is allowed to overlap the bounds
+                if progressed && (caret.x + word_max_x).ceil() > self.width_bound {
                     break;
                 }
             }


### PR DESCRIPTION
The later vertex generation logic already ensures no glyph can escape the bounds anyway, so the bounds will still be respected. Now the first word can be truncated by the bounds.

Actually turned out to be a one-liner thanks to the new layout code, this behaviour should be more expected. It's also pretty important for the new vertical alignment options to work properly.

Resolves #32 

## Before
![](https://user-images.githubusercontent.com/2331607/42096931-9a9b1960-7bae-11e8-9e13-0e6a2248abdb.png)

## After
![](https://user-images.githubusercontent.com/2331607/42096932-9bd7b068-7bae-11e8-87e5-428a6dc1edc5.png)